### PR TITLE
Add GetNir from pad file

### DIFF
--- a/bucket/getnir.json
+++ b/bucket/getnir.json
@@ -1,27 +1,27 @@
 {
-    "version": "0",
+    "version": "1.00",
     "homepage": "https://www.nirsoft.net/utils/get_nir_command_line_tool.html",
     "url": "https://www.nirsoft.net/utils/getnir.zip",
     "bin": "GetNir.exe",
     "shortcuts": [
-     [
-      "GetNir.exe",
-      "NirSoft\\GetNir"
-     ]
+        [
+            "GetNir.exe",
+            "NirSoft\\GetNir"
+        ]
     ],
     "persist": [
-     "getnir_lng.ini",
-     "getnir.cfg"
+        "getnir_lng.ini",
+        "getnir.cfg"
     ],
     "hash": "cb0291f4f3990fd62aaadb372e5c54eff6ad4920f5b8fa6531d0c0abd1560da8",
     "description": "Command line tool to extract values from tab-delimited and comma-delimited data",
     "license": "Freeware",
     "notes": "If this application is useful to you, please consider donating to nirsoft.",
     "checkver": {
-     "url": "https://www.nirsoft.net/pad/getnir.xml",
-     "xpath": "/XML_DIZ_INFO/Program_Info/Program_Version"
+        "url": "https://www.nirsoft.net/pad/getnir.xml",
+        "xpath": "/XML_DIZ_INFO/Program_Info/Program_Version"
     },
     "autoupdate": {
-     "url": "https://www.nirsoft.net/utils/getnir.zip"
+        "url": "https://www.nirsoft.net/utils/getnir.zip"
     }
 }

--- a/bucket/getnir.json
+++ b/bucket/getnir.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.00",
+    "version": "0",
     "homepage": "https://www.nirsoft.net/utils/get_nir_command_line_tool.html",
     "url": "https://www.nirsoft.net/utils/getnir.zip",
     "bin": "GetNir.exe",

--- a/getnir.json
+++ b/getnir.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.00",
+    "homepage": "https://www.nirsoft.net/utils/get_nir_command_line_tool.html",
+    "url": "https://www.nirsoft.net/utils/getnir.zip",
+    "bin": "GetNir.exe",
+    "shortcuts": [
+     [
+      "GetNir.exe",
+      "NirSoft\\GetNir"
+     ]
+    ],
+    "persist": [
+     "getnir_lng.ini",
+     "getnir.cfg"
+    ],
+    "hash": "cb0291f4f3990fd62aaadb372e5c54eff6ad4920f5b8fa6531d0c0abd1560da8",
+    "description": "Command line tool to extract values from tab-delimited and comma-delimited data",
+    "license": "Freeware",
+    "notes": "If this application is useful to you, please consider donating to nirsoft.",
+    "checkver": {
+     "url": "https://www.nirsoft.net/pad/getnir.xml",
+     "xpath": "/XML_DIZ_INFO/Program_Info/Program_Version"
+    },
+    "autoupdate": {
+     "url": "https://www.nirsoft.net/utils/getnir.zip"
+    }
+}


### PR DESCRIPTION
Used the python script to create the manifest. It set the version number to 0, but the pad file lists it at 1.00, so I changed it to that. I also filled in the hash.